### PR TITLE
PIPRES-180: Order state duplication on reset fix

### DIFF
--- a/src/Adapter/ConfigurationAdapter.php
+++ b/src/Adapter/ConfigurationAdapter.php
@@ -12,12 +12,21 @@
 
 namespace Mollie\Adapter;
 
+use Context;
 use Shop;
 
 class ConfigurationAdapter
 {
     public function get($key, $idShop = null, $idLang = null, $idShopGroup = null)
     {
+        if (!$idShop) {
+            $idShop = Context::getContext()->shop->id;
+        }
+
+        if (!$idShopGroup) {
+            $idShopGroup = Context::getContext()->shop->id_shop_group;
+        }
+
         return \Configuration::get($key, $idLang, $idShopGroup, $idShop);
     }
 

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -437,6 +437,10 @@ class Installer implements InstallerInterface
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_COMPLETED, $this->configurationAdapter->get(Config::MOLLIE_STATUS_ORDER_COMPLETED));
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_CANCELED, Configuration::get('PS_OS_CANCELED'));
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_EXPIRED, Configuration::get('PS_OS_CANCELED'));
+        $this->configurationAdapter->updateValue(
+            Config::MOLLIE_STATUS_PARTIAL_REFUND,
+            $this->configurationAdapter->get(Configuration::get(Config::MOLLIE_STATUS_PARTIAL_REFUND))
+        );
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_REFUNDED, Configuration::get('PS_OS_REFUND'));
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_SHIPPING, $this->configurationAdapter->get(Config::MOLLIE_STATUS_PARTIALLY_SHIPPED));
         $this->configurationAdapter->updateValue(Config::MOLLIE_MAIL_WHEN_SHIPPING, true);

--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -432,17 +432,13 @@ class Installer implements InstallerInterface
         $this->configurationAdapter->updateValue(Config::MOLLIE_METHOD_COUNTRIES, 0);
         $this->configurationAdapter->updateValue(Config::MOLLIE_METHOD_COUNTRIES_DISPLAY, 0);
         $this->configurationAdapter->updateValue(Config::MOLLIE_DISPLAY_ERRORS, false);
-        $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_OPEN, Configuration::get(Config::MOLLIE_STATUS_AWAITING));
+        $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_OPEN, $this->configurationAdapter->get(Config::MOLLIE_STATUS_AWAITING));
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_PAID, Configuration::get('PS_OS_PAYMENT'));
-        $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_COMPLETED, Configuration::get(Config::MOLLIE_STATUS_ORDER_COMPLETED));
+        $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_COMPLETED, $this->configurationAdapter->get(Config::MOLLIE_STATUS_ORDER_COMPLETED));
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_CANCELED, Configuration::get('PS_OS_CANCELED'));
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_EXPIRED, Configuration::get('PS_OS_CANCELED'));
-        $this->configurationAdapter->updateValue(
-            Config::MOLLIE_STATUS_PARTIAL_REFUND,
-            Configuration::get(Config::MOLLIE_STATUS_PARTIAL_REFUND)
-        );
         $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_REFUNDED, Configuration::get('PS_OS_REFUND'));
-        $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_SHIPPING, Configuration::get(Config::MOLLIE_STATUS_PARTIALLY_SHIPPED));
+        $this->configurationAdapter->updateValue(Config::MOLLIE_STATUS_SHIPPING, $this->configurationAdapter->get(Config::MOLLIE_STATUS_PARTIALLY_SHIPPED));
         $this->configurationAdapter->updateValue(Config::MOLLIE_MAIL_WHEN_SHIPPING, true);
         $this->configurationAdapter->updateValue(Config::MOLLIE_MAIL_WHEN_PAID, true);
         $this->configurationAdapter->updateValue(Config::MOLLIE_MAIL_WHEN_COMPLETED, true);
@@ -554,7 +550,7 @@ class Installer implements InstallerInterface
 
     private function isStatusCreated($statusName)
     {
-        $status = new OrderState((int) Configuration::get($statusName));
+        $status = new OrderState((int) $this->configurationAdapter->get($statusName));
         if (Validate::isLoadedObject($status)) {
             $this->enableStatus($status);
 


### PR DESCRIPTION
Configuration adapter was not used for checking if order state was installed. Also modified adapter to get id shop and id shop group from context if not passed. This issue persisted only on multishop as legacy configuration class automatically sets id shop and id shop group if multishop is deactivated.
Also found weird config setter when exactly same configuration item is being set after it was set in order state install.